### PR TITLE
fix: use __REDUX_DEVTOOLS_EXTENSION_COMPOSE__ to avoid Redux error #0

### DIFF
--- a/apps/arrows-ts/src/main.tsx
+++ b/apps/arrows-ts/src/main.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom/client';
 import thunkMiddleware from 'redux-thunk'
 import {render} from 'react-dom';
 import {Provider} from 'react-redux'
-import {createStore, applyMiddleware} from 'redux'
+import {createStore, applyMiddleware, compose} from 'redux'
 
 import reducer from './reducers'
 
@@ -29,10 +29,11 @@ const middleware = [
   imageCacheMiddleware
 ]
 
+const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+
 const store = createStore(
   reducer,
-  (window as any).__REDUX_DEVTOOLS_EXTENSION__ && (window as any).__REDUX_DEVTOOLS_EXTENSION__(),
-  applyMiddleware(thunkMiddleware, ...middleware)
+  composeEnhancers(applyMiddleware(thunkMiddleware, ...middleware))
 )
 initGoogleDriveApi(store)
 store.dispatch(windowResized(window.innerWidth, window.innerHeight))


### PR DESCRIPTION
## Summary

- Replaces the old `__REDUX_DEVTOOLS_EXTENSION__` pattern in `createStore` with the correct `__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` approach
- The old pattern broke when the Redux DevTools browser extension was installed, causing a blank screen with "Minified Redux error #0"
- Falls back to Redux's own `compose` when the extension is not present, so behavior is unchanged for users without DevTools installed

## Root cause

The old code passed two separate enhancers to `createStore`:
```js
createStore(reducer, devtoolsEnhancer, applyMiddleware(...))
```
This is only safe in certain Redux 4.x code paths and breaks with the DevTools extension's newer API. The correct pattern composes them into one:
```js
const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
createStore(reducer, composeEnhancers(applyMiddleware(...)))
```

Fixes #133